### PR TITLE
Yield controller builder to blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,18 +125,18 @@ Targets:
 * `role="option"`
 
 ```html+erb
-<form <%= aria.combobox %> data-turbo-frame="names">
+<%= aria.combobox.tag.form data: { turbo_frame: "names" } do |builder| %>
   <label for="query">Names</label>
-  <input id="query" <%= aria.combobox.combobox_target.merge aria: { expanded: params[:query].present? } %> type="search" name="query">
+  <input id="query" <%= builder.combobox_target.merge aria: { expanded: params[:query].present? } %> type="search" name="query">
 
-  <turbo-frame <%= aria.combobox.listbox_target %> id="names">
+  <turbo-frame <%= builder.listbox_target %> id="names">
     <% if params[:query].present? %>
       <% %w[ Alan Alex Alice Barbara Bill Bob ].filter { |name| name.starts_with? params[:query] }.each_with_index do |name, id| %>
-        <%= aria.combobox.option_target.tag.button name, type: "button", id: "name_#{id}", aria: { selected: id.zero? } %>
+        <%= builder.option_target.tag.button name, type: "button", id: "name_#{id}", aria: { selected: id.zero? } %>
       <% end %>
     <% end %>
   </turbo-frame>
-</form>
+<% end %>
 ```
 
 #### Actions
@@ -347,27 +347,27 @@ When `defer_selection_value:` is provided, embeds:
 * `data-tabs-defer-selection-value`
 
 ```html+erb
-<div <%= aria.tabs %> id="tabs">
-  <div <%= aria.tabs.tablist_target %> id="tabs-tablist">
-    <button <%= aria.tabs.tab_target %> id="tabs-first-tab" type="button"
+<%= aria.tabs.tag id: "tabs" do |builder| %>
+  <%= builder.tablist_target.tag id: "tabs-tablist" do %>
+    <button <%= builder.tab_target %> id="tabs-first-tab" type="button"
             aria-controls="tabs-first-tabpanel">
       First tab
     </button>
 
-    <button <%= aria.tabs.tab_target %> id="tabs-second-tab" type="button"
+    <button <%= builder.tab_target %> id="tabs-second-tab" type="button"
             aria-controls="tabs-second-tabpanel">
       Second tab
     </button>
-  </div>
+  <% end %>
 
-  <div <%= aria.tabs.tabpanel_target %> id="tabs-first-tabpanel">
+  <%= builder.tabpanel_target.tag id: "tabs-first-tabpanel" do %>
     First panel content
-  </div>
+  <% end %>
 
-  <div <%= aria.tabs.tabpanel_target %> id="tabs-second-tabpanel">
+  <%= builder.tabpanel_target.tag id: "tabs-second-tabpanel" do %>
     Second panel content
-  </div>
-</div>
+  <% end %>
+<% end %>
 ```
 
 #### Actions

--- a/lib/stimulus/controller.rb
+++ b/lib/stimulus/controller.rb
@@ -54,9 +54,13 @@ module Stimulus
 
     def tag(**options, &block)
       if options.any? || block.present?
-        attributes.with_attributes(**options).content_tag(default_tag_name, &block)
+        attributes.with_attributes(**options).content_tag(default_tag_name) do
+          @view_context.capture { yield_self(&block) }
+        end
       else
-        attributes.tag
+        DelegatorWithClosure.new(attributes.tag) do |closure|
+          @view_context.capture { yield_self(&closure) }
+        end
       end
     end
   end

--- a/lib/stimulus/delegator_with_closure.rb
+++ b/lib/stimulus/delegator_with_closure.rb
@@ -1,0 +1,20 @@
+module Stimulus
+  class DelegatorWithClosure
+    def initialize(delegate, &closure)
+      @delegate = delegate
+      @closure = closure
+    end
+
+    ruby2_keywords def method_missing(*arguments, &block)
+      if block.present? && block.arity == 1
+        @delegate.public_send(*arguments) { block.yield_self(&@closure) }
+      else
+        @delegate.public_send(*arguments, &block)
+      end
+    end
+
+    ruby2_keywords def respond_to_missing?(*arguments)
+      @delegate.respond_to_missing?(*arguments)
+    end
+  end
+end

--- a/test/dummy/app/views/examples/index.html.erb
+++ b/test/dummy/app/views/examples/index.html.erb
@@ -55,30 +55,30 @@
 
 <a href="#feed" data-turbo="false">Skip to #feed</a>
 
-<%= aria.feed.tag id: "feed" do %>
-  <%= aria.feed.article_target.tag.article id: "article_1" do %>
+<%= aria.feed.tag id: "feed" do |builder| %>
+  <%= builder.article_target.tag.article id: "article_1" do %>
     First article
   <% end %>
-  <%= aria.feed.article_target.tag.article id: "article_2" do %>
+  <%= builder.article_target.tag.article id: "article_2" do %>
     Second article
   <% end %>
-  <%= aria.feed.article_target.tag.article id: "article_3" do %>
+  <%= builder.article_target.tag.article id: "article_3" do %>
     Third article
   <% end %>
 <% end %>
 
 <hr>
 
-<%= aria.combobox.tag.form(data: { controller: "form", action: "input->form#requestSubmit", turbo_frame: "names" }) do %>
+<%= aria.combobox.tag.form(data: { controller: "form", action: "input->form#requestSubmit", turbo_frame: "names" }) do |builder| %>
   <button type="button" data-action="click->combobox#expand">Expand combobox</button>
 
   <label for="query">Names</label>
-  <input id="query" <%= aria.combobox.combobox_target %> type="search" name="query" aria-expanded="<%= params[:query].present? %>">
+  <input id="query" <%= builder.combobox_target %> type="search" name="query" aria-expanded="<%= params[:query].present? %>">
 
-  <turbo-frame <%= aria.combobox.listbox_target %> id="names">
+  <turbo-frame <%= builder.listbox_target %> id="names">
     <% if params[:query].present? %>
       <% %w[ Alan Alex Alice Barbara Bill Bob ].filter { |name| name.starts_with? params[:query] }.each_with_index do |name, id| %>
-        <button id="name_<%= id %>" type="button" <%= aria.combobox.option_target %> aria-selected="<%= id.zero? %>"><%= name %></button>
+        <button id="name_<%= id %>" type="button" <%= builder.option_target %> aria-selected="<%= id.zero? %>"><%= name %></button>
       <% end %>
     <% end %>
   </turbo-frame>
@@ -88,93 +88,93 @@
 
 <a href="#tabs-horizontal" data-turbo="false">Skip to #tabs-horizontal</a>
 
-<%= aria.tabs.tag id: "tabs-horizontal" do %>
-  <%= aria.tabs.tablist_target.tag.div id: "tabs-horizontal-tablist" do %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-horizontal-first-tab", type: "button",
-                                        aria: { controls: "tabs-horizontal-first-panel" } do %>
+<%= aria.tabs.tag id: "tabs-horizontal" do |builder| %>
+  <%= builder.tablist_target.tag.div id: "tabs-horizontal-tablist" do %>
+    <%= builder.tab_target.tag.button id: "tabs-horizontal-first-tab", type: "button",
+                                      aria: { controls: "tabs-horizontal-first-panel" } do %>
       First horizontal tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-horizontal-second-tab", type: "button",
-                                        aria: { controls: "tabs-horizontal-second-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-horizontal-second-tab", type: "button",
+                                      aria: { controls: "tabs-horizontal-second-panel" } do %>
       Second horizontal tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-horizontal-third-tab", type: "button",
-                                        aria: { controls: "tabs-horizontal-third-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-horizontal-third-tab", type: "button",
+                                      aria: { controls: "tabs-horizontal-third-panel" } do %>
       Third horizontal tab
     <% end %>
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-horizontal-first-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-horizontal-first-panel" do %>
     First horizontal panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-horizontal-second-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-horizontal-second-panel" do %>
     Second horizontal panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-horizontal-third-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-horizontal-third-panel" do %>
     Third horizontal panel
   <% end %>
 <% end %>
 
 <a href="#tabs-vertical" data-turbo="false">Skip to #tabs-vertical</a>
 
-<%= aria.tabs.tag id: "tabs-vertical" do %>
-  <%= aria.tabs.tablist_target.tag.div id: "tabs-vertical-tablist", aria: { orientation: "vertical" } do %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-vertical-first-tab", type: "button", style: "display: block;",
-                                        aria: { controls: "tabs-vertical-first-panel" } do %>
+<%= aria.tabs.tag id: "tabs-vertical" do |builder| %>
+  <%= builder.tablist_target.tag.div id: "tabs-vertical-tablist", aria: { orientation: "vertical" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-vertical-first-tab", type: "button", style: "display: block;",
+                                      aria: { controls: "tabs-vertical-first-panel" } do %>
       First vertical tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-vertical-second-tab", type: "button", style: "display: block;",
-                                        aria: { controls: "tabs-vertical-second-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-vertical-second-tab", type: "button", style: "display: block;",
+                                      aria: { controls: "tabs-vertical-second-panel" } do %>
       Second vertical tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-vertical-third-tab", type: "button", style: "display: block;",
-                                        aria: { controls: "tabs-vertical-third-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-vertical-third-tab", type: "button", style: "display: block;",
+                                      aria: { controls: "tabs-vertical-third-panel" } do %>
       Third vertical tab
     <% end %>
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-vertical-first-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-vertical-first-panel" do %>
     First vertical panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-vertical-second-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-vertical-second-panel" do %>
     Second vertical panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-vertical-third-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-vertical-third-panel" do %>
     Third vertical panel
   <% end %>
 <% end %>
 
 <a href="#tabs-click-to-select" data-turbo="false">Skip to #tabs-click-to-select</a>
 
-<%= aria.tabs(defer_selection_value: true).tag id: "tabs-click-to-select" do %>
-  <%= aria.tabs.tablist_target.tag.div id: "tabs-click-to-select-tablist" do %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-click-to-select-first-tab", type: "button",
-                                        aria: { controls: "tabs-click-to-select-first-panel" } do %>
+<%= aria.tabs(defer_selection_value: true).tag id: "tabs-click-to-select" do |builder| %>
+  <%= builder.tablist_target.tag.div id: "tabs-click-to-select-tablist" do %>
+    <%= builder.tab_target.tag.button id: "tabs-click-to-select-first-tab", type: "button",
+                                      aria: { controls: "tabs-click-to-select-first-panel" } do %>
       First click-to-select tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-click-to-select-second-tab", type: "button",
-                                        aria: { controls: "tabs-click-to-select-second-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-click-to-select-second-tab", type: "button",
+                                      aria: { controls: "tabs-click-to-select-second-panel" } do %>
       Second click-to-select tab
     <% end %>
-    <%= aria.tabs.tab_target.tag.button id: "tabs-click-to-select-third-tab", type: "button",
-                                        aria: { controls: "tabs-click-to-select-third-panel" } do %>
+    <%= builder.tab_target.tag.button id: "tabs-click-to-select-third-tab", type: "button",
+                                      aria: { controls: "tabs-click-to-select-third-panel" } do %>
       Third click-to-select tab
     <% end %>
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-click-to-select-first-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-click-to-select-first-panel" do %>
     First click-to-select panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-click-to-select-second-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-click-to-select-second-panel" do %>
     Second click-to-select panel
   <% end %>
 
-  <%= aria.tabs.tabpanel_target.tag.div id: "tabs-click-to-select-third-panel" do %>
+  <%= builder.tabpanel_target.tag.div id: "tabs-click-to-select-third-panel" do %>
     Third click-to-select panel
   <% end %>
 <% end %>

--- a/test/system/disclosure_controller_test.rb
+++ b/test/system/disclosure_controller_test.rb
@@ -14,11 +14,11 @@ require "application_system_test_case"
    test "disclosure toggles CSS class" do
      visit examples_path
 
-     assert_no_css "#css-class.expanded", text: "CSS class"
+     assert_no_element id: "css-class", class: "expanded", text: "CSS class"
      assert_disclosure_button "Toggle CSS class", expanded: false
 
-     click_on("Toggle CSS class").then { assert_css "#css-class.expanded", text: "CSS class" }
-     click_on("Toggle CSS class").then { assert_no_css "#css-class.expanded", text: "CSS class" }
+     toggle_disclosure("Toggle CSS class").then { assert_element id: "css-class", class: "expanded", text: "CSS class" }
+     toggle_disclosure("Toggle CSS class").then { assert_no_element id: "css-class", class: "expanded", text: "CSS class" }
    end
 
    test "disclosure toggles hidden" do
@@ -27,11 +27,19 @@ require "application_system_test_case"
      assert_text "Visible"
      assert_disclosure_button "Toggle Hidden", expanded: false
 
-     click_on("Toggle Hidden").then { assert_no_text "Visible" }
-     click_on("Toggle Hidden").then { assert_text "Visible" }
+     toggle_disclosure("Toggle Hidden").then { assert_no_text "Visible" }
+     toggle_disclosure("Toggle Hidden").then { assert_text "Visible" }
    end
 
    private
+
+   def assert_element(*arguments, **options, &block)
+     assert_selector(:element, *arguments, **options, &block)
+   end
+
+   def assert_no_element(*arguments, **options, &block)
+     assert_no_selector(:element, *arguments, **options, &block)
+   end
 
    def assert_disclosure(locator, **options)
      assert_selector :disclosure, locator, **options


### PR DESCRIPTION
When invoking a controller with a block, provide the opportunity for
callers to declare a block parameter.

For example, consider the `[role="combobox"]` example code:

```erb
<%= aria.combobox.tag.form data: { turbo_frame: "names" } do %>
  <label for="query">Names</label>
  <input id="query" <%= aria.combobox.combobox_target.merge aria: { expanded: params[:query].present? } %> type="search" name="query">

  <turbo-frame <%= aria.combobox.listbox_target %> id="names">
    <% if params[:query].present? %>
      <% %w[ Alan Alex Alice Barbara Bill Bob ].filter { |name| name.starts_with? params[:query] }.each_with_index do |name, id| %>
        <%= aria.combobox.option_target.tag.button name, type: "button", id: "name_#{id}", aria: { selected: id.zero? } %>
      <% end %>
    <% end %>
  </turbo-frame>
<% end %>
```

Within the `aria.combobox.tag.form` call's block, the code prefixes
several invocations with the `aria.combobox.` chain. Not only could that
contribute to noise in the code, it also invokes a new
`Stimulus::Controller` each time. If the instance constructed by the
`aria.combobox` call were to capture any state (e.g. a
`autocomplete_value: true` Stmiulus Value), that configuration would be
lost to any instances invoked within the block.

This commit adds support for yielding the controller instance as a block
parameter:

```diff
-<%= aria.combobox.tag.form data: { turbo_frame: "names" } do %>
+<%= aria.combobox.tag.form data: { turbo_frame: "names" } do |builder| %>
   <label for="query">Names</label>
-  <input id="query" <%= aria.combobox.combobox_target.merge aria: { expanded: params[:query].present? } %> type="search" name="query">
+  <input id="query" <%= builder.combobox_target.merge aria: { expanded: params[:query].present? } %> type="search" name="query">

-  <turbo-frame <%= aria.combobox.listbox_target %> id="names">
+  <turbo-frame <%= builder.listbox_target %> id="names">
     <% if params[:query].present? %>
       <% %w[ Alan Alex Alice Barbara Bill Bob ].filter { |name| name.starts_with? params[:query] }.each_with_index do |name, id| %>
-        <%= aria.combobox.option_target.tag.button name, type: "button", id: "name_#{id}", aria: { selected: id.zero? } %>
+        <%= builder.option_target.tag.button name, type: "button", id: "name_#{id}", aria: { selected: id.zero? } %>
       <% end %>
     <% end %>
   </turbo-frame>
 <% end %>
```