### PR TITLE
Omit `[role="option"]` from tab order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- By default, render Combobox `[role="option]` elements with `[tabindex="-1"]`
+  to omit them from the page's tab order
+- By default, render Combobox `[role="combobox"]` element with
+  `[autocomplete="off"]`

--- a/lib/stimulus_aria_widgets/combobox_controller.rb
+++ b/lib/stimulus_aria_widgets/combobox_controller.rb
@@ -2,8 +2,9 @@ module StimulusAriaWidgets
   class ComboboxController < Stimulus::Controller
     attributes data: { action: "input->combobox#expand" }
 
-    target "combobox", role: "combobox", data: { action: "keydown->combobox#navigate" }
+    target "combobox", role: "combobox", autocomplete: "off",
+                       data: { action: "keydown->combobox#navigate" }
     target "listbox", role: "listbox"
-    target "option", role: "option"
+    target "option", role: "option", tabindex: "-1"
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,6 +9,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   private
 
+  def tab_until_focused(*arguments, **options, &block)
+    using_wait_time false do
+      send_keys(:tab) until page.has_selector?(*arguments, **options, focused: true, &block)
+    end
+  end
+
   def append(erb, into:, locals: {})
     html = ApplicationController.renderer.render(inline: erb, locals: locals)
 

--- a/test/dummy/app/views/examples/index.html.erb
+++ b/test/dummy/app/views/examples/index.html.erb
@@ -1,6 +1,8 @@
 <style>
   dialog        { display: none; }
   dialog[open]  { display: block; }
+
+  [aria-selected="true"] { border: dotted black 1px; }
 </style>
 
 <%= aria.disclosure.tag(aria: { controls: "dialog" }) do %>

--- a/test/system/combobox_controller_test.rb
+++ b/test/system/combobox_controller_test.rb
@@ -55,6 +55,14 @@ class ComboboxControllerTest < ApplicationSystemTestCase
     send_keys(:end).then              { assert_list_box_option "Alice", selected: true }
   end
 
+  test "omits options from tab order" do
+    visit examples_path
+    tab_until_focused :field, "Names"
+
+    send_keys("Al").then { assert_list_box_option "Alan", selected: true }
+    send_keys(:tab).then { assert_link focused: true }
+  end
+
   private
 
   def assert_combo_box(locator = nil, **options)

--- a/test/system/grid_controller_test.rb
+++ b/test/system/grid_controller_test.rb
@@ -163,10 +163,4 @@ class GridControllerTest < ApplicationSystemTestCase
   def assert_gridcell(*arguments, **options, &block)
     assert_selector(:gridcell, *arguments, **options, &block)
   end
-
-  def tab_until_focused(*arguments, **options, &block)
-    using_wait_time false do
-      send_keys(:tab) until page.has_selector?(*arguments, **options, focused: true, &block)
-    end
-  end
 end


### PR DESCRIPTION
By default, render Combobox `[role="option]` elements with
`[tabindex="-1"]` to omit them from the page's tab order

Similarly, render the Combobox `[role="combobox"]` element with
`[autocomplete="off"]` so that browsers don't present their built-in
autocomplete menu overlaid on top of the `[role="listbox"]`.