### PR TITLE
`Stimulus::Controller.target` configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,27 +139,29 @@ application.register("combobox", ComboboxController)
 
 #### Helpers
 
-`aria.combobox` embeds attributes on the root element:
+`aria.combobox` renders attributes on the root element:
 
 * `data-controller="combobox"`
 * `data-action="input->combobox#expand"`
 
 Targets:
 
-`aria.combobox.combobox_target` embeds attributes:
+`aria.combobox.combobox_target` default attributes:
 
 * `role="combobox"`
+* `autocomplete="off"`
 * `data-combobox-target="combobox"`
 * `data-action="keydown->combobox#navigate"`
 
-`aria.combobox.listbox_target` embeds attributes:
+`aria.combobox.listbox_target` default attributes:
 
 * `role="listbox"`
 * `data-combobox-target="listbox"`
 
-`aria.combobox.option_target` embeds attributes:
+`aria.combobox.option_target` default attributes:
 
 * `role="option"`
+* `tabindex="-1"`
 
 ```html+erb
 <%= aria.combobox.tag.form data: { turbo_frame: "names" } do |builder| %>
@@ -200,13 +202,13 @@ application.register("disclosure", DisclosureController)
 
 Calls to `aria.disclosure.tag` render a `<button>` by default.
 
-`aria.disclosure(expanded_class:)` embeds attributes on the root element:
+`aria.disclosure(expanded_class:)` default attributes on the root element:
 
 * `data-controller="disclosure"`
 * `data-action="click->disclosure#toggle"`
 * `type="button"`
 
-When `expanded_class:` is provided, embeds:
+When `expanded_class:` is provided, renders:
 
 * `data-disclosure-expanded-class`
 
@@ -263,7 +265,7 @@ application.register("dialog", DialogController)
 
 #### Helpers
 
-`aria.dialog` embeds attributes on the root element:
+`aria.dialog` renders attributes on the root element:
 
 * `role="dialog"`
 * `data-controller="dialog"`
@@ -311,7 +313,7 @@ application.register("feed", FeedController)
 
 #### Helpers
 
-`aria.feed` embeds attributes on the root element:
+`aria.feed` renders attributes on the root element:
 
 * `role="feed"`
 * `data-controller="feed"`
@@ -319,7 +321,7 @@ application.register("feed", FeedController)
 
 Targets:
 
-`aria.feed.article_target` embeds attributes:
+`aria.feed.article_target` default attributes:
 
 * `data-feed-target="article"`
 
@@ -357,30 +359,30 @@ application.register("tabs", TabsController)
 
 #### Helpers
 
-`aria.tabs(defer_selection_value: Boolean)` embeds attributes on the root element:
+`aria.tabs(defer_selection_value: Boolean)` renders attributes on the root element:
 
 * `data-controller="tabs"`
 
 Targets:
 
-`aria.tabs.tablist_target` embeds attributes:
+`aria.tabs.tablist_target` default attributes:
 
 * `role="tablist"`
 * `data-tabs-target="tablist"`
 * `data-action="keydown->tabs#navigate"`
 
-`aria.tabs.tab_target` embeds attributes:
+`aria.tabs.tab_target` default attributes:
 
 * `role="tab"`
 * `data-tabs-target="tab"`
 * `data-action="click->tabs#select"`
 
-`aria.tabs.tabpanel_target` embeds attributes:
+`aria.tabs.tabpanel_target` default attributes:
 
 * `role="tabpanel"`
 * `data-tabs-target="tabpanel"`
 
-When `defer_selection_value:` is provided, embeds:
+When `defer_selection_value:` is provided, renders:
 
 * `data-tabs-defer-selection-value`
 
@@ -431,7 +433,7 @@ application.register("grid", GridController)
 
 #### Helpers
 
-`aria.grid` embeds attributes on the root element:
+`aria.grid` renders attributes on the root element:
 
 * `data-controller="grid"`
 
@@ -439,14 +441,14 @@ Calls to `aria.grid.tag` default to rendering `<table>` elements
 
 Targets:
 
-`aria.grid.row_target` embeds attributes:
+`aria.grid.row_target` default attributes:
 
 * `role="row"`
 * `data-grid-target="row"`
 * `data-action="keydown->grid#moveRow"`
 * `data-grid-directions-param="{"ArrowDown":1,"ArrowUp":-1,"PageDown":10,"PageUp":-10}"`
 
-`aria.grid.gridcell_target` embeds attributes:
+`aria.grid.gridcell_target` default attributes:
 
 * `role="gridcell"`
 * `data-grid-target="gridcell"`
@@ -465,16 +467,16 @@ Targets:
   </thead>
 
   <tbody>
-    <%= builder.row_target.tag.tr do %>
-      <%= builder.gridcell_target.tag.td "A1" %>
-      <%= builder.gridcell_target.tag.td "A2" %>
-      <%= builder.gridcell_target.tag.td "A3" %>
+    <%= builder.row_target.tag do %>
+      <%= builder.gridcell_target.tag "A1" %>
+      <%= builder.gridcell_target.tag "A2" %>
+      <%= builder.gridcell_target.tag "A3" %>
     <% end %>
 
-    <%= builder.row_target.tag.tr do %>
-      <%= builder.gridcell_target.tag.td "B1" %>
-      <%= builder.gridcell_target.tag.td "B2" %>
-      <%= builder.gridcell_target.tag.td "B3" %>
+    <%= builder.row_target.tag do %>
+      <%= builder.gridcell_target.tag "B1" %>
+      <%= builder.gridcell_target.tag "B2" %>
+      <%= builder.gridcell_target.tag "B3" %>
     <% end %>
   </tbody>
 <% end %>

--- a/lib/stimulus/target.rb
+++ b/lib/stimulus/target.rb
@@ -1,0 +1,61 @@
+module Stimulus
+  class Target
+    class_attribute :separator, default: "_"
+
+    delegate_missing_to :attributes
+
+    def initialize(name, view_context, controller, default_tag_name = "div")
+      @name = name
+      @view_context = view_context
+      @controller = controller
+      @default_tag_name = default_tag_name
+      @attributes = @view_context.tag.attributes
+      @params = HashWithIndifferentAccess.new
+    end
+
+    def tag_name(tag_name)
+      @default_tag_name = tag_name
+    end
+
+    def attributes(**defaults)
+      if defaults.present?
+        @attributes.deep_merge!(defaults)
+      else
+        attribute = [ @controller.identifier, :target ].join(separator)
+        token_list = @view_context.token_list(@name)
+
+        @attributes.deep_merge(data: { attribute => token_list, **params })
+      end
+    end
+
+    def params(**defaults)
+      if defaults.present?
+        @params.deep_merge!(defaults)
+      else
+        @params.transform_keys { |key| [ @controller.identifier, key, :param ].join(separator) }
+      end
+    end
+
+    ruby2_keywords def tag(*arguments, &block)
+      options = arguments.extract_options!
+
+      if arguments.any? || options.any? || block.present?
+        if arguments.any?
+          attributes.with_attributes(**options).content_tag(@default_tag_name, *arguments)
+        else
+          attributes.with_attributes(**options).content_tag(@default_tag_name) do
+            @view_context.capture { yield_self(&block) }
+          end
+        end
+      else
+        DelegatorWithClosure.new(attributes.tag) do |closure|
+          @view_context.capture { yield_self(&closure) }
+        end
+      end
+    end
+
+    def to_s
+      attributes.to_s
+    end
+  end
+end

--- a/lib/stimulus_aria_widgets/combobox_controller.rb
+++ b/lib/stimulus_aria_widgets/combobox_controller.rb
@@ -2,8 +2,13 @@ module StimulusAriaWidgets
   class ComboboxController < Stimulus::Controller
     attributes data: { action: "input->combobox#expand" }
 
-    target "combobox", role: "combobox", autocomplete: "off",
-                       data: { action: "keydown->combobox#navigate" }
+    target "combobox" do
+      tag_name "input"
+
+      attributes role: "combobox", autocomplete: "off",
+                 data: { action: "keydown->combobox#navigate" }
+    end
+
     target "listbox", role: "listbox"
     target "option", role: "option", tabindex: "-1"
   end

--- a/lib/stimulus_aria_widgets/feed_controller.rb
+++ b/lib/stimulus_aria_widgets/feed_controller.rb
@@ -2,6 +2,8 @@ module StimulusAriaWidgets
   class FeedController < Stimulus::Controller
     attributes role: "feed", data: { action: "keydown->feed#navigate" }
 
-    target "article"
+    target "article" do
+      tag_name "article"
+    end
   end
 end

--- a/lib/stimulus_aria_widgets/grid_controller.rb
+++ b/lib/stimulus_aria_widgets/grid_controller.rb
@@ -4,14 +4,21 @@ module StimulusAriaWidgets
 
     attributes role: "grid"
 
-    target "row", role: "row", data: {
-      action: "keydown->grid#moveRow",
-      grid_directions_param: { ArrowDown: +1, ArrowUp: -1, PageDown: +10, PageUp: -10 },
-    }
-    target "gridcell", role: "gridcell", data: {
-      action: "focus->grid#captureFocus keydown->grid#moveColumn",
-      grid_boundaries_param: { Home: 0, End: 1 },
-      grid_directions_param: { ArrowRight: +1, ArrowLeft: -1 },
-    }
+    target "row" do
+      tag_name "tr"
+
+      attributes role: "row", data: { action: "keydown->grid#moveRow" }
+
+      params directions: { ArrowDown: +1, ArrowUp: -1, PageDown: +10, PageUp: -10 }
+    end
+
+    target "gridcell" do
+      tag_name "td"
+
+      attributes role: "gridcell", data: { action: "focus->grid#captureFocus keydown->grid#moveColumn" }
+
+      params boundaries: { Home: 0, End: 1 }
+      params directions: { ArrowRight: +1, ArrowLeft: -1 }
+    end
   end
 end

--- a/test/dummy/app/views/examples/index.html.erb
+++ b/test/dummy/app/views/examples/index.html.erb
@@ -5,9 +5,9 @@
   [aria-selected="true"] { border: dotted black 1px; }
 </style>
 
-<%= aria.disclosure.tag(aria: { controls: "dialog" }) do %>
+<button <%= aria.disclosure %> aria-controls="dialog">
   Open Dialog
-<% end %>
+</button>
 
 <%= aria.dialog.tag(id: "dialog") do %>
   <h1 id="dialog-title">Modal Dialog</h1>
@@ -58,13 +58,13 @@
 <a href="#feed" data-turbo="false">Skip to #feed</a>
 
 <%= aria.feed.tag id: "feed" do |builder| %>
-  <%= builder.article_target.tag.article id: "article_1" do %>
+  <%= builder.article_target.tag id: "article_1" do %>
     First article
   <% end %>
-  <%= builder.article_target.tag.article id: "article_2" do %>
+  <%= builder.article_target.tag id: "article_2" do %>
     Second article
   <% end %>
-  <%= builder.article_target.tag.article id: "article_3" do %>
+  <%= builder.article_target.tag id: "article_3" do %>
     Third article
   <% end %>
 <% end %>
@@ -75,7 +75,7 @@
   <button type="button" data-action="click->combobox#expand">Expand combobox</button>
 
   <label for="query">Names</label>
-  <input id="query" <%= builder.combobox_target %> type="search" name="query" aria-expanded="<%= params[:query].present? %>">
+  <%= builder.combobox_target.tag id: "query", type: "search", name: "query", aria: { expanded: params[:query].present? } %>
 
   <turbo-frame <%= builder.listbox_target %> id="names">
     <% if params[:query].present? %>
@@ -195,22 +195,22 @@
   </thead>
 
   <tbody>
-    <%= builder.row_target.tag.tr do %>
-      <%= builder.gridcell_target.tag.td "A1" %>
-      <%= builder.gridcell_target.tag.td "A2" %>
-      <%= builder.gridcell_target.tag.td "A3" %>
+    <%= builder.row_target.tag do %>
+      <%= builder.gridcell_target.tag "A1" %>
+      <%= builder.gridcell_target.tag "A2" %>
+      <%= builder.gridcell_target.tag "A3" %>
     <% end %>
 
-    <%= builder.row_target.tag.tr do %>
-      <%= builder.gridcell_target.tag.td "B1" %>
-      <%= builder.gridcell_target.tag.td "B2" %>
-      <%= builder.gridcell_target.tag.td "B3" %>
+    <%= builder.row_target.tag do %>
+      <%= builder.gridcell_target.tag "B1" %>
+      <%= builder.gridcell_target.tag "B2" %>
+      <%= builder.gridcell_target.tag "B3" %>
     <% end %>
 
-    <%= builder.row_target.tag.tr do %>
-      <%= builder.gridcell_target.tag.td "C1" %>
-      <%= builder.gridcell_target.tag.td "C2" %>
-      <%= builder.gridcell_target.tag.td "C3" %>
+    <%= builder.row_target.tag do %>
+      <%= builder.gridcell_target.tag "C1" %>
+      <%= builder.gridcell_target.tag "C2" %>
+      <%= builder.gridcell_target.tag "C3" %>
     <% end %>
   </tbody>
 


### PR DESCRIPTION
Prior to this change, a target target within controllers were limited
to accepting a name and a set of default HTML attributes, deferring the
responsibility of choosing a tag name callers.

In most circumstances, it was a suitable solution. However, there are
some targets that would benefit from a default tag. For example,
defaulting the `FeedController#article_target` to an `<article>`
element, the `ComboboxController#combobox_target` to an `<input>`
element, the `GridController#gridcell_target` to an `<td>`, etc.

To support that use case, this commit introduces the `Target` class, and
modifies the `Stimulus::Controller.target` definition to forward any
configuration (along with any block argument) to that newly constructed
instance.